### PR TITLE
Update stable repo url

### DIFF
--- a/entry
+++ b/entry
@@ -64,7 +64,7 @@ helm_repo_init() {
 
 	if [ "$HELM" == "helm_v3" ]; then
 		if [[ $CHART == stable/* ]]; then
-			$HELM repo add stable https://kubernetes-charts.storage.googleapis.com/
+			$HELM repo add stable https://charts.helm.sh/stable
 			$HELM repo update
 		fi
 	else


### PR DESCRIPTION
Im getting errors by default because of the old url no longer working.

Ref: https://helm.sh/blog/new-location-stable-incubator-charts/