### PR TITLE
Update stable repo URL for helm_v2 init

### DIFF
--- a/entry
+++ b/entry
@@ -64,7 +64,7 @@ helm_repo_init() {
 
 	if [ "$HELM" == "helm_v3" ]; then
 		if [[ $CHART == stable/* ]]; then
-			$HELM repo add stable https://charts.helm.sh/stable/
+			$HELM repo add stable $STABLE_REPO_URL
 			$HELM repo update
 		fi
 	else
@@ -104,7 +104,7 @@ if [ "$BOOTSTRAP" != "true" ]; then
   tiller --listen=127.0.0.1:44134 --storage=secret &
   export HELM_HOST=127.0.0.1:44134
 
-  helm_v2 init --skip-refresh --client-only
+  helm_v2 init --skip-refresh --client-only --stable-repo-url $STABLE_REPO_URL
   EXIST=$(helm_v2 ls --all "^$NAME\$" --output json | jq -r '.Releases | length')
 fi
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,3 +11,4 @@ RUN apk add -U --no-cache ca-certificates jq bash git
 COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]
+ENV STABLE_REPO_URL=https://charts.helm.sh/stable/


### PR DESCRIPTION
Fixes CI test failures:

```
helm_v2 init --skip-refresh --client-only
[main] 2021/01/07 23:40:21 Starting Tiller v2.16.10 (tls=false)
[main] 2021/01/07 23:40:21 GRPC listening on 127.0.0.1:44134
[main] 2021/01/07 23:40:21 Probes listening on :44135
[main] 2021/01/07 23:40:21 Storage driver is Secret
[main] 2021/01/07 23:40:21 Max history per release is 0
Creating /root/.helm
Creating /root/.helm/repository
Creating /root/.helm/repository/cache
Creating /root/.helm/repository/local
Creating /root/.helm/plugins
Creating /root/.helm/starters
Creating /root/.helm/cache/archive
Creating /root/.helm/repository/repositories.yaml
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
Adding local repo with URL: http://127.0.0.1:8879/charts

...

+ helm_v2 repo update --strict
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Unable to get an update from the "stable" chart repository (https://kubernetes-charts.storage.googleapis.com):
	Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
Error: Update Failed. Check log for details
+ helm_v2 repo remove stable
"stable" has been removed from your repositories
+ '[' -n '' ']'
+ helm_update install --version 1.86.1 --set rbac.enabled=true --set ssl.enabled=true
+ '[' helm_v2 == helm_v3 ']'
++ helm_v2 ls --all '^traefik-update-example-v2$' --output json
++ jq -r '"\(.Releases[0].AppVersion),\(.Releases[0].Status)"'
++ tr '[:upper:]' '[:lower:]'
[storage] 2021/01/07 23:40:22 listing all releases with filter
+ LINE=
++ echo
++ cut -f1 -d,
+ INSTALLED_VERSION=
++ echo
++ cut -f2 -d,
+ STATUS=
+ VALUES=
+ '[' install = delete ']'
+ '[' -z '' ']'
+ '[' -z '' ']'
+ helm_v2 install --version 1.86.1 --set rbac.enabled=true --set ssl.enabled=true --name traefik-update-example-v2 stable/traefik
Error: failed to download "stable/traefik" (hint: running `helm repo update` may help)
```