### PR TITLE
Add helm-set-status plugin to handle pending releases

### DIFF
--- a/entry
+++ b/entry
@@ -33,8 +33,25 @@ helm_update() {
 		exit
 	fi
 
-	# Upgrade only if the status is already deployed, or if a previous upgrade was interrupted
-	if [[ "${STATUS}" =~ ^(deployed|pending-upgrade)$ ]]; then
+	# If a previous helm_v3 operation was interrupted unexpectedly, set it to failed.
+	if [[ "${STATUS}" =~ ^(pending-install|pending-upgrade|pending-rollback)$ ]] && [[ "${HELM}" == "helm_v3" ]]; then
+		echo Previous helm job was interrupted, updating status from ${STATUS} to failed
+		${HELM} set-status ${NAME} failed --namespace ${TARGET_NAMESPACE}
+
+		# Upgrades can be retried; install and rollback will be handled as failure below.
+		# If this upgrade also fails, retries of the job will handle that as failure due to the release state change.
+		if [[ "${STATUS}" == "pending-upgrade" ]]; then
+			echo "Retrying upgrade of ${NAME}"
+			shift 1
+			${HELM} upgrade "$@" ${NAME} ${CHART} ${TIMEOUT_ARG} ${VALUES}
+			exit
+		else
+			STATUS=failed
+		fi
+	fi
+
+	# Upgrade only if the chart is already deployed
+	if [[ "${STATUS}" == "deployed" ]]; then
 		echo Already installed ${NAME}, upgrading
 		shift 1
 		${HELM} upgrade "$@" ${NAME} ${CHART} ${TIMEOUT_ARG} ${VALUES}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -7,7 +7,7 @@ RUN curl https://get.helm.sh/helm-v3.5.4-linux-${ARCH}.tar.gz | tar xvzf - --str
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 
 FROM golang:1.16-alpine3.12 as plugins
-RUN apk add -U curl ca-certificates build-base
+RUN apk add -U curl ca-certificates build-base binutils-gold
 ARG ARCH
 COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -6,9 +6,18 @@ RUN mv /usr/bin/helm /usr/bin/helm_v2
 RUN curl https://get.helm.sh/helm-v3.5.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 
+FROM golang:1.16-alpine3.12 as plugins
+RUN apk add -U curl ca-certificates build-base
+ARG ARCH
+COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
+RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
+    curl -L https://github.com/k3s-io/helm-set-status/archive/refs/tags/v0.1.1.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \
+    make -C /go/src/github.com/k3s-io/helm-set-status install
+
 FROM alpine:3.12
 RUN apk add -U --no-cache ca-certificates jq bash git
 COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
+COPY --from=plugins /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/


### PR DESCRIPTION
Attempt to handle interrupted upgrades by retrying once; stuck install/rollback will be handled as failed and cause an uninstall/reinstall