### PR TITLE
Allow for non-root klipper-helm operation

### DIFF
--- a/entry
+++ b/entry
@@ -101,7 +101,7 @@ helm_repo_init() {
 helm_content_decode() {
 	set -e
 	ENC_CHART_PATH="/chart/${NAME}.tgz.base64"
-	CHART_PATH="/${NAME}.tgz"
+	CHART_PATH="/tmp/${NAME}.tgz"
 	if [[ ! -f "${ENC_CHART_PATH}" ]]; then
 		return
 	fi
@@ -110,7 +110,8 @@ helm_content_decode() {
 	set +e
 }
 
-HELM="helm_v3"
+export HELM_TLS_CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+HELM="helm_v3 --ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 NAME_ARG=""
 TIMEOUT_ARG=""
 JQ_CMD='"\(.[0].app_version),\(.[0].status)"'
@@ -118,9 +119,6 @@ JQ_CMD='"\(.[0].app_version),\(.[0].status)"'
 set -e -v
 CHART="${CHART//%\{KUBERNETES_API\}%/${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}}"
 set +v -x
-
-cp /var/run/secrets/kubernetes.io/serviceaccount/ca.crt /usr/local/share/ca-certificates/
-update-ca-certificates
 
 if [[ "${BOOTSTRAP}" != "true" ]]; then
 	tiller --listen=127.0.0.1:44134 --storage=secret &

--- a/entry
+++ b/entry
@@ -111,7 +111,7 @@ helm_content_decode() {
 }
 
 export HELM_TLS_CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-HELM="helm_v3 --ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+HELM="helm_v3"
 NAME_ARG=""
 TIMEOUT_ARG=""
 JQ_CMD='"\(.[0].app_version),\(.[0].status)"'

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -22,7 +22,6 @@ COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
 COPY --from=plugins /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]
-ENV HOME=/home/klipper-helm
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/
 ENV TIMEOUT=
 USER 1000

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,10 +15,15 @@ RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     make -C /go/src/github.com/k3s-io/helm-set-status install
 
 FROM alpine:3.12
-RUN apk add -U --no-cache ca-certificates jq bash git
+WORKDIR /home/klipper-helm
+ENV HOME=/home/klipper-helm
 COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
 COPY --from=plugins /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
 COPY entry /usr/bin/
+RUN apk add -U --no-cache ca-certificates jq bash git && \
+    chown 1000:1000 -R /home/klipper-helm && \
+    chmod +x /usr/bin/entry
 ENTRYPOINT ["entry"]
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/
 ENV TIMEOUT=
+USER 1000

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,8 +18,8 @@ FROM alpine:3.12
 RUN apk add -U --no-cache ca-certificates jq bash git && \
     adduser -D -u 1000 -s /bin/bash klipper-helm
 WORKDIR /home/klipper-helm
-COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
-COPY --from=plugins /root/.local/share/helm/plugins/ /home/klipper-helm/.local/share/helm/plugins/
+COPY --chown=1000:1000 --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
+COPY --chown=1000:1000 --from=plugins /root/.local/share/helm/plugins/ /home/klipper-helm/.local/share/helm/plugins/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -15,15 +15,14 @@ RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     make -C /go/src/github.com/k3s-io/helm-set-status install
 
 FROM alpine:3.12
+RUN apk add -U --no-cache ca-certificates jq bash git && \
+    adduser -D -u 1000 -s /bin/bash klipper-helm
 WORKDIR /home/klipper-helm
-ENV HOME=/home/klipper-helm
 COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
 COPY --from=plugins /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
 COPY entry /usr/bin/
-RUN apk add -U --no-cache ca-certificates jq bash git && \
-    chown 1000:1000 -R /home/klipper-helm && \
-    chmod +x /usr/bin/entry
 ENTRYPOINT ["entry"]
+ENV HOME=/home/klipper-helm
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/
 ENV TIMEOUT=
 USER 1000

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:3.12
 RUN apk add -U --no-cache ca-certificates jq bash git && \
     adduser -D -u 1000 -s /bin/bash klipper-helm
 WORKDIR /home/klipper-helm
-COPY --chown=1000:1000 --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
+COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
 COPY --chown=1000:1000 --from=plugins /root/.local/share/helm/plugins/ /home/klipper-helm/.local/share/helm/plugins/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add -U --no-cache ca-certificates jq bash git && \
     adduser -D -u 1000 -s /bin/bash klipper-helm
 WORKDIR /home/klipper-helm
 COPY --from=extract /usr/bin/helm_v2 /usr/bin/helm_v3 /usr/bin/tiller /usr/bin/
-COPY --from=plugins /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
+COPY --from=plugins /root/.local/share/helm/plugins/ /home/klipper-helm/.local/share/helm/plugins/
 COPY entry /usr/bin/
 ENTRYPOINT ["entry"]
 ENV STABLE_REPO_URL=https://charts.helm.sh/stable/


### PR DESCRIPTION
klipper-helm does not need to use the root user. In environments where policies prevent root users in containers without necessity, it is difficult to use this image.