### PR TITLE
Support private repository with username and password

### DIFF
--- a/entry
+++ b/entry
@@ -100,7 +100,14 @@ helm_repo_init() {
 	fi
 
 	if [[ -n "${REPO}" ]]; then
-		${HELM} repo add ${NAME%%/*} ${REPO}
+	  REPO_REGEX="^((http|https):\/\/)((\S+):(\S+)@)?(\S+\.+\S+)$"
+	  [[ ${REPO} =~ ${REPO_REGEX} ]]
+	  if [[ ${#BASH_REMATCH[*]} -eq 7 && -n ${BASH_REMATCH[4]} && -n ${BASH_REMATCH[5]} ]]; then
+	    echo "add private repo with username and password"
+	    ${HELM} repo add ${NAME%%/*} ${BASH_REMATCH[1]}${BASH_REMATCH[6]} --username ${BASH_REMATCH[4]} --password ${BASH_REMATCH[5]}
+	  else
+		  ${HELM} repo add ${NAME%%/*} ${REPO}
+		fi
 		${HELM} repo update
 	fi
 }


### PR DESCRIPTION
I created this pull request to solve the problem of this issue: https://github.com/k3s-io/helm-controller/issues/100

If the repository URL contains a username with password, then the username and password
will be extracted and with the separate Helm repo arguments '--username' and '--password' passed to Helm.