### PR TITLE
Enforce 30 second limit on checking for old Helm v2 chart

### DIFF
--- a/entry
+++ b/entry
@@ -134,7 +134,7 @@ if [[ "${BOOTSTRAP}" != "true" ]]; then
 	export HELM_HOST=127.0.0.1:44134
 
 	helm_v2 init --skip-refresh --client-only --stable-repo-url ${STABLE_REPO_URL}
-	V2_CHART_EXISTS=$(helm_v2 ls --all "^${NAME}\$" --output json | jq -r '.Releases | length')
+	V2_CHART_EXISTS=$(timeout -s KILL 30 helm_v2 ls --all "^${NAME}\$" --output json | jq -r '.Releases | length')
 fi
 
 if [[ "${V2_CHART_EXISTS}" == "1" ]] || [[ "${HELM_VERSION}" == "v2" ]]; then


### PR DESCRIPTION
We are very unlikely to still have any helm v2 charts around, and apparently helm v2 won't reconnect to Tiller even if we restart it in a loop... so the only way to work around this crash is to just give up after 30 seconds to prevent blocking the whole install job.