### PR TITLE
Add ipv6 support

### DIFF
--- a/entry
+++ b/entry
@@ -33,7 +33,7 @@ helm_update() {
 	# No current version and status, safe to install
 	if [[ "${INSTALLED_VERSION}" =~ ^(|null)$ ]] && [[ "${STATUS}" =~ ^(|null)$ ]]; then
 		echo "Installing ${HELM} chart" >> ${TERM_LOG}
-		${HELM} "$@" ${NAME_ARG} ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+		${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
 		exit
 	fi
 
@@ -49,7 +49,7 @@ helm_update() {
 			echo "Retrying upgrade of ${HELM} chart" >> ${TERM_LOG}
 			echo "Retrying upgrade of ${NAME}"
 			shift 1
-			${HELM} upgrade "$@" ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+			${HELM} upgrade "$@" ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
 			exit
 		else
 			STATUS=failed
@@ -68,7 +68,7 @@ helm_update() {
 		echo "Upgrading ${HELM} chart" >> ${TERM_LOG}
 		echo "Upgrading ${NAME}"
 		shift 1
-		${HELM} upgrade "$@" ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+		${HELM} upgrade "$@" ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
 		exit
 	fi
 
@@ -96,7 +96,7 @@ helm_update() {
 
 	# No special status handling necessary, do whatever we were asked to do
 	echo "Installing ${HELM} chart" >> ${TERM_LOG}
-	${HELM} "$@" ${NAME_ARG} ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+	${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
 }
 
 helm_repo_init() {
@@ -146,7 +146,13 @@ TIMEOUT_ARG=""
 JQ_CMD='"\(.[0].app_version),\(.[0].status)"'
 
 set -e -v
-CHART="${CHART//%\{KUBERNETES_API\}%/${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}}"
+if [[ ${KUBERNETES_SERVICE_HOST} =~ .*:.* ]]; then
+	echo "KUBERNETES_SERVICE_HOST is using IPv6"
+	CHART="${CHART//%\{KUBERNETES_API\}%/[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}}"
+else
+	CHART="${CHART//%\{KUBERNETES_API\}%/${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}}"
+fi
+
 set +v -x
 
 if [[ "${BOOTSTRAP}" != "true" ]]; then


### PR DESCRIPTION
When we are in a ipv6-only env, the KUBERNETES_SERVICE_HOST env variable is an ipv6 variable. In that case, we need [ ] to wrap the address.

When that happens, {CHART} needs quotes to avoid bash evaluation. I checked and it does not create a regression with ipv4 addresses

https://github.com/k3s-io/k3s/issues/5237#issuecomment-1075468736 

Signed-off-by: Manuel Buil <mbuil@suse.com>