### PR TITLE
pass --cacert flags to `helm repo` commands too

### DIFF
--- a/entry
+++ b/entry
@@ -33,7 +33,7 @@ helm_update() {
 	# No current version and status, safe to install
 	if [[ "${INSTALLED_VERSION}" =~ ^(|null)$ ]] && [[ "${STATUS}" =~ ^(|null)$ ]]; then
 		echo "Installing ${HELM} chart" >> ${TERM_LOG}
-		${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+		${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${TIMEOUT_ARG} ${VALUES}
 		exit
 	fi
 
@@ -49,7 +49,7 @@ helm_update() {
 			echo "Retrying upgrade of ${HELM} chart" >> ${TERM_LOG}
 			echo "Retrying upgrade of ${NAME}"
 			shift 1
-			${HELM} upgrade "$@" ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+			${HELM} upgrade "$@" ${NAME} "${CHART}" ${TIMEOUT_ARG} ${VALUES}
 			exit
 		else
 			STATUS=failed
@@ -68,7 +68,7 @@ helm_update() {
 		echo "Upgrading ${HELM} chart" >> ${TERM_LOG}
 		echo "Upgrading ${NAME}"
 		shift 1
-		${HELM} upgrade "$@" ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+		${HELM} upgrade "$@" ${NAME} "${CHART}" ${TIMEOUT_ARG} ${VALUES}
 		exit
 	fi
 
@@ -85,7 +85,7 @@ helm_update() {
 			echo Deleted
 			# Try installing now that we've uninstalled
 			echo "Installing ${HELM} chart" >> ${TERM_LOG}
-			${HELM} "$@" ${NAME_ARG} ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+			${HELM} "$@" ${NAME_ARG} ${NAME} ${CHART} ${TIMEOUT_ARG} ${VALUES}
 			exit
 		else
 			echo "Release status is '${STATUS}' and failure policy is '${FAILURE_POLICY}', not 'reinstall'; waiting for operator intervention" >> ${TERM_LOG}
@@ -96,7 +96,7 @@ helm_update() {
 
 	# No special status handling necessary, do whatever we were asked to do
 	echo "Installing ${HELM} chart" >> ${TERM_LOG}
-	${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+	${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${TIMEOUT_ARG} ${VALUES}
 }
 
 helm_repo_init() {
@@ -109,7 +109,7 @@ helm_repo_init() {
 
 	if [[ "${HELM}" == "helm_v3" ]]; then
 		if [[ ${CHART} == stable/* ]]; then
-			${HELM} repo add stable ${STABLE_REPO_URL}
+			${HELM} repo add ${CA_FILE_ARG} stable ${STABLE_REPO_URL}
 			${HELM} repo update
 		fi
 	else
@@ -117,7 +117,7 @@ helm_repo_init() {
 	fi
 
 	if [[ -n "${REPO}" ]]; then
-		${HELM} repo add ${NAME%%/*} ${REPO}
+		${HELM} repo add ${CA_FILE_ARG} ${NAME%%/*} ${REPO}
 		${HELM} repo update
 	fi
 }


### PR DESCRIPTION
* https://github.com/k3s-io/helm-controller/issues/89

The job fails otherwise with the following:

```
+ helm_v3 repo add x 'https://x'
Error: looks like "https://x" is not a valid chart repository or cannot be reached: Get "https://x/index.yaml": x509: certificate signed by unknown authority
```