### PR TITLE
Bump alpine/golang/helm versions

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.15
+FROM golang:1.19-alpine3.16
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.15 as extract
+FROM alpine:3.16 as extract
 RUN apk add -U curl ca-certificates
 ARG ARCH
 RUN curl https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl https://get.helm.sh/helm-v3.8.1-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl https://get.helm.sh/helm-v3.10.2-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 COPY entry /usr/bin/
 
-FROM golang:1.18-alpine3.15 as plugins
+FROM golang:1.19-alpine3.16 as plugins
 RUN apk add -U curl ca-certificates build-base binutils-gold
 ARG ARCH
 COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
@@ -15,7 +15,7 @@ RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     curl -sL https://github.com/k3s-io/helm-set-status/archive/refs/tags/v0.1.2.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \
     make -C /go/src/github.com/k3s-io/helm-set-status install
 RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
-    curl -sL https://github.com/helm/helm-mapkubeapis/archive/refs/tags/v0.3.0.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/helm/helm-mapkubeapis && \
+    curl -sL https://github.com/helm/helm-mapkubeapis/archive/refs/tags/v0.3.2.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/helm/helm-mapkubeapis && \
     make -C /go/src/github.com/helm/helm-mapkubeapis && \
     mkdir -p /root/.local/share/helm/plugins/helm-mapkubeapis && \
     cp -vr /go/src/github.com/helm/helm-mapkubeapis/plugin.yaml \
@@ -23,8 +23,11 @@ RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
            /go/src/github.com/helm/helm-mapkubeapis/config \
            /root/.local/share/helm/plugins/helm-mapkubeapis/
 
-FROM alpine:3.15
-RUN apk add -U --no-cache ca-certificates jq bash git && \
+FROM alpine:3.16
+ARG BUILDDATE
+LABEL buildDate=$BUILDDATE
+RUN apk --no-cache upgrade && \
+    apk add -U --no-cache ca-certificates jq bash git && \
     adduser -D -u 1000 -s /bin/bash klipper-helm
 WORKDIR /home/klipper-helm
 COPY --chown=1000:1000 --from=plugins /root/.local/share/helm/plugins/ /home/klipper-helm/.local/share/helm/plugins/

--- a/scripts/package
+++ b/scripts/package
@@ -21,5 +21,5 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-docker build --build-arg ARCH=${ARCH} -f ${DOCKERFILE} -t ${IMAGE} .
+docker build --build-arg ARCH=${ARCH} --build-arg BUILDDATE=$(date +%Y%m%d) -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
Also, inject BUILDDATE as cache-bust to ensure that packages get updated in final stage to address vulns.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>