### PR TITLE
`plugins/docker:latest` is no longer published for ARM 32-bit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,8 @@ steps:
     path: /var/run/docker.sock
 
 - name: docker-publish
-  image: plugins/docker
+  # latest tag is no longer available for ARM 32-bit
+  image: plugins/docker:linux-arm
   settings:
     dockerfile: package/Dockerfile
     password:


### PR DESCRIPTION
`plugins/docker:latest` is no longer published for ARM 32-bit, we need to use `plugins/docker:linux-arm` tag instead.

Fixes failing Drone `tag` pipeline - https://drone-publish.k3s.io/k3s-io/klipper-helm/20/3/3.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>