### PR TITLE
Pass --wait flag to `helm uninstall` commands

### DIFF
--- a/entry
+++ b/entry
@@ -21,7 +21,7 @@ helm_update() {
 		fi
 		if [[ "${HELM}" == "helm_v3" ]]; then
 			echo "Uninstalling ${HELM} chart" >> ${TERM_LOG}
-			${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} || true
+			${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait || true
 		else
 			echo "Deleting and purging ${HELM} chart" >> ${TERM_LOG}
 			${HELM} delete ${NAME} || true
@@ -77,7 +77,7 @@ helm_update() {
 		if [[ "${FAILURE_POLICY:-reinstall}" == "reinstall" ]]; then
 			if [[ "${HELM}" == "helm_v3" ]]; then
 				echo "Uninstalling ${STATUS} ${HELM} chart" >> ${TERM_LOG}
-				${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE}
+				${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait
 			else
 				echo "Purging ${STATUS} ${HELM} chart" >> ${TERM_LOG}
 				${HELM} "$@" --purge ${NAME}


### PR DESCRIPTION
I ran into an issue with the default "reinstall" failurePolicy when installing [airflow](https://github.com/airflow-helm/charts/tree/airflow-8.2.0/charts/airflow).  The timeout limit was reached during install (because of a slow post-install hook), so `helm uninstall` was triggered.  PVCs were in the "Terminating" state when `helm install` kicked again, and were not created when the released installed the second time around.

This PR adds the `--wait` flag to all `helm uninstall` commands to ensure that resources are deleted before `helm install` runs again.