### PR TITLE
Add support for RISC-V

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -133,6 +133,50 @@ volumes:
 
 ---
 kind: pipeline
+name: riscv64
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: rancher/dapper:v0.5.0
+  commands:
+  - dapper ci
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: docker-publish
+  image: plugins/docker
+  settings:
+    dockerfile: package/Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/klipper-helm"
+    tag: "${DRONE_TAG}-riscv64"
+    username:
+      from_secret: docker_username
+    build_args:
+    - ARCH=riscv64
+  when:
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: manifest
 
 platform:
@@ -151,6 +195,7 @@ steps:
       - linux/amd64
       - linux/arm64
       - linux/arm
+      - linux/riscv64
     target: "rancher/klipper-helm:${DRONE_TAG}"
     template: "rancher/klipper-helm:${DRONE_TAG}-ARCH"
   when:
@@ -166,6 +211,7 @@ depends_on:
 - amd64
 - arm64
 - arm
+- riscv64
 
 ...
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -4,7 +4,7 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN apk -U add bash docker-cli docker-cli-buildx git
-ENV DAPPER_ENV REPO TAG DRONE_TAG
+ENV DAPPER_ENV REPO TAG DRONE_TAG ARCH
 ENV DAPPER_SOURCE /go/src/github.com/k3s-io/klipper-helm/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,7 +5,7 @@ RUN curl -sL https://get.helm.sh/helm-v3.16.1-linux-${ARCH}.tar.gz | tar xvzf - 
 COPY entry /usr/bin/
 
 FROM golang:1.23-alpine3.20 as plugins
-RUN apk add -U curl ca-certificates build-base binutils-gold
+RUN apk add -U curl ca-certificates build-base
 ARG ARCH
 COPY --from=extract /usr/bin/helm /usr/bin/helm
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \

--- a/scripts/package
+++ b/scripts/package
@@ -21,5 +21,9 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-docker build --build-arg ARCH=${ARCH} --build-arg BUILDDATE=$(date +%Y%m%d) -f ${DOCKERFILE} -t ${IMAGE} .
+if [ "$ARCH" = "riscv64" ]; then
+    export DOCKER_BUILDKIT=1
+    DOCKER_ARGS="--platform=$ARCH"
+fi
+docker build ${DOCKER_ARGS} --build-arg ARCH=${ARCH} --build-arg BUILDDATE=$(date +%Y%m%d) -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
Since Helm does not provide riscv64 binaries yet, I use a separate `Dockerfile` that builds from source. I have already submitted a [PR to Helm for releasing a RISC-V binary](https://github.com/helm/helm/pull/12204). When it is merged, the `Dockerfile.riscv64` can be simplified.

The `entry` script has also been modified to function without Helm v2. Helm v2 is deprecated, a release has not been made for close to 3 years, and according to [the documentation](https://helm.sh/docs/topics/v2_v3_migration/#overview-of-helm-3-changes) v2 charts can also be installed with Helm v3. The new `entry` script should function even when Helm v2 is required, but can also be easily modified to fail with an error.

The work is part of an ongoing effort to run [K3s on RISC-V](https://github.com/k3s-io/k3s/pull/7778). In K3s, klipper-helm is used to install Traefik, which is part of the default deployment.

The resulting container image, built with `ARCH=riscv64 make` has been tested on QEMU and is working fine.