### PR TITLE
Use `chart` instead of `app_version` when checking installed version

### DIFF
--- a/entry
+++ b/entry
@@ -158,7 +158,7 @@ NAME_ARG=""
 CA_FILE_ARG=""
 TIMEOUT_ARG=""
 PASS_CREDENTIALS_ARG=""
-JQ_CMD='"\(.[0].app_version),\(.[0].status)"'
+JQ_CMD='"\(.[0].chart),\(.[0].status)"'
 
 set -e -v
 if [[ ${KUBERNETES_SERVICE_HOST} =~ .*:.* ]]; then


### PR DESCRIPTION
Currently, the entrypoint is looking at a Chart's `app_version` to set `INSTALLED_VERSION`, and then checks if that variable is an empty string before uninstalling the chart.

This works well when `appVersion` is defined in `Chart.yaml`, but if not you'll be met with a _"nothing to delete"_ error and the release will not uninstall as expected.  For example:

```
# kubectl -n kube-system logs helm-delete-foo-trzf2 | tail -13
++ helm_v3 ls --all -f '^foo$' --namespace my-namespace --output json
++ tr '[:upper:]' '[:lower:]'
++ jq -r '"\(.[0].app_version),\(.[0].status)"'
+ LINE=,deployed
+ IFS=,
+ read -r INSTALLED_VERSION STATUS _
+ VALUES=
+ for VALUES_FILE in /config/*.yaml
+ VALUES=' --values /config/values-01_HelmChart.yaml'
+ [[ delete = \d\e\l\e\t\e ]]
+ [[ -z '' ]]
+ echo 'No helm_v3 chart installed; nothing to delete'
+ exit

# helm ls --all -f '^foo$' --namespace my-namespace --output json
[{"name":"foo","namespace":"my-namespace","revision":"1","updated":"2023-07-20 20:56:49.76550025 +0000 UTC","status":"deployed","chart":"foo-0.7.4","app_version":""}]
```

According to [Helm documentation](https://helm.sh/docs/topics/charts/), `appVersion` is an optional field in `Chart.yaml`.

This PR updates the entrypoint to look at the `chart` instead of `app_version` to determine if a release is installed.  This should be a safer check because all Helm releases are guaranteed to have this information.  