### PR TITLE
fix: IPv6 support

### DIFF
--- a/entry
+++ b/entry
@@ -85,7 +85,7 @@ helm_update() {
 			echo Deleted
 			# Try installing now that we've uninstalled
 			echo "Installing ${HELM} chart" >> ${TERM_LOG}
-			${HELM} "$@" ${NAME_ARG} ${NAME} ${CHART} ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
+			${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${TIMEOUT_ARG} ${VALUES}
 			exit
 		else
 			echo "Release status is '${STATUS}' and failure policy is '${FAILURE_POLICY}', not 'reinstall'; waiting for operator intervention" >> ${TERM_LOG}


### PR DESCRIPTION
This contribution adds an occurence, missed by the original PR that introduced IPv6 (https://github.com/k3s-io/klipper-helm/pull/43). Now, also in the case of reinstalling, the script works as expected in IPv6 environments.