### PR TITLE
Bump alpine/helmv3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -130,55 +130,7 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
----
-kind: pipeline
-name: s390x
-type: docker
 
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-- name: build
-  image: rancher/dapper:v0.5.8
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: docker-publish
-  image: rancher/drone-images:docker-s390x
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/klipper-helm"
-    tag: "${DRONE_TAG}-s390x"
-    username:
-      from_secret: docker_username
-    build_args:
-    - ARCH=s390x
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
 ---
 kind: pipeline
 name: manifest
@@ -199,7 +151,6 @@ steps:
       - linux/amd64
       - linux/arm64
       - linux/arm
-      - linux/s390x
     target: "rancher/klipper-helm:${DRONE_TAG}"
     template: "rancher/klipper-helm:${DRONE_TAG}-ARCH"
   when:
@@ -215,7 +166,6 @@ depends_on:
 - amd64
 - arm64
 - arm
-- s390x
 
 ...
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,4 @@
-# need to stick with alpine 3.17 for docker 20.10 until the s390x runners are upgraded
-# ref: https://github.com/alpinelinux/docker-alpine/issues/182
-FROM alpine:3.17
+FROM alpine:3.19
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.18 as extract
+FROM alpine:3.19 as extract
 RUN apk add -U curl ca-certificates
 ARG ARCH
 RUN curl https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl https://get.helm.sh/helm-v3.12.3-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl https://get.helm.sh/helm-v3.14.2-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 COPY entry /usr/bin/
 
-FROM golang:1.20-alpine3.18 as plugins
+FROM golang:1.20-alpine3.19 as plugins
 RUN apk add -U curl ca-certificates build-base binutils-gold
 ARG ARCH
 COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
@@ -23,7 +23,7 @@ RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
            /go/src/github.com/helm/helm-mapkubeapis/config \
            /root/.local/share/helm/plugins/helm-mapkubeapis/
 
-FROM alpine:3.18
+FROM alpine:3.19
 ARG BUILDDATE
 LABEL buildDate=$BUILDDATE
 RUN apk --no-cache upgrade && \


### PR DESCRIPTION
Also drop s390x since we no longer have build infra

Ref:
* [Dependency management path traversal](https://github.com/helm/helm/security/advisories/GHSA-v53g-5gjp-272r)
* [Missing YAML Content Leads To Panic](https://github.com/helm/helm/security/advisories/GHSA-r53h-jv2g-vpx6)