### PR TITLE
Add support for auth via TLS Secret

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -132,55 +132,6 @@ volumes:
     path: /var/run/docker.sock
 ---
 kind: pipeline
-name: s390x
-type: docker
-
-platform:
-  os: linux
-  arch: amd64
-
-node:
-  arch: s390x
-
-steps:
-- name: build
-  image: rancher/dapper:v0.5.8
-  commands:
-  - dapper ci
-  volumes:
-  - name: docker
-    path: /var/run/docker.sock
-
-- name: docker-publish
-  image: rancher/drone-images:docker-s390x
-  volumes:
-    - name: docker
-      path: /var/run/docker.sock
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/klipper-helm"
-    tag: "${DRONE_TAG}-s390x"
-    username:
-      from_secret: docker_username
-    build_args:
-    - ARCH=s390x
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-volumes:
-- name: docker
-  host:
-    path: /var/run/docker.sock
----
-kind: pipeline
 name: manifest
 
 platform:
@@ -199,7 +150,6 @@ steps:
       - linux/amd64
       - linux/arm64
       - linux/arm
-      - linux/s390x
     target: "rancher/klipper-helm:${DRONE_TAG}"
     template: "rancher/klipper-helm:${DRONE_TAG}-ARCH"
   when:
@@ -215,7 +165,6 @@ depends_on:
 - amd64
 - arm64
 - arm
-- s390x
 
 ...
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,9 @@
-# need to stick with alpine 3.17 for docker 20.10 until the s390x runners are upgraded
-# ref: https://github.com/alpinelinux/docker-alpine/issues/182
-FROM alpine:3.17
+FROM alpine:3.19
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash docker-cli git
+RUN apk -U add bash docker-cli docker-cli-buildx git
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/k3s-io/klipper-helm/
 ENV DAPPER_OUTPUT ./bin ./dist

--- a/entry
+++ b/entry
@@ -127,6 +127,11 @@ helm_repo_init() {
 				PASS_CREDENTIALS_ARG="--pass-credentials"
 			fi
 			cat ${AUTH_DIR}/password | ${HELM} repo add ${CA_FILE_ARG} ${PASS_CREDENTIALS_ARG} --username "$(cat ${AUTH_DIR}/username)" --password-stdin ${NAME%%/*} ${REPO}
+		elif [[ -f "${AUTH_DIR}/tls.crt" ]] && [[ -f "${AUTH_DIR}/tls.key" ]]; then
+			if [[ "${AUTH_PASS_CREDENTIALS}" == "true" ]]; then
+				PASS_CREDENTIALS_ARG="--pass-credentials"
+			fi
+			${HELM} repo add ${CA_FILE_ARG} ${PASS_CREDENTIALS_ARG} --cert-file ${AUTH_DIR}/tls.crt --key-file ${AUTH_DIR}/tls.key ${NAME%%/*} ${REPO}
 		else
 			${HELM} repo add ${CA_FILE_ARG} ${NAME%%/*} ${REPO}
 		fi

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:3.18 as extract
+FROM alpine:3.19 as extract
 RUN apk add -U curl ca-certificates
 ARG ARCH
-RUN curl https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl -sL https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl https://get.helm.sh/helm-v3.12.3-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl -sL https://get.helm.sh/helm-v3.15.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 COPY entry /usr/bin/
 
-FROM golang:1.20-alpine3.18 as plugins
+FROM golang:1.22-alpine3.19 as plugins
 RUN apk add -U curl ca-certificates build-base binutils-gold
 ARG ARCH
 COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
@@ -23,7 +23,7 @@ RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
            /go/src/github.com/helm/helm-mapkubeapis/config \
            /root/.local/share/helm/plugins/helm-mapkubeapis/
 
-FROM alpine:3.18
+FROM alpine:3.19
 ARG BUILDDATE
 LABEL buildDate=$BUILDDATE
 RUN apk --no-cache upgrade && \


### PR DESCRIPTION
Currently the `spec.authSecret` must be a [Basic authentication Secret](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret). This adds support for [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).

* https://github.com/k3s-io/k3s/issues/10124