### PR TITLE
Add support for auth via TLS Secret

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,7 +3,7 @@ FROM alpine:3.19
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash docker-cli git
+RUN apk -U add bash docker-cli docker-cli-buildx git
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/k3s-io/klipper-helm/
 ENV DAPPER_OUTPUT ./bin ./dist

--- a/entry
+++ b/entry
@@ -127,6 +127,11 @@ helm_repo_init() {
 				PASS_CREDENTIALS_ARG="--pass-credentials"
 			fi
 			cat ${AUTH_DIR}/password | ${HELM} repo add ${CA_FILE_ARG} ${PASS_CREDENTIALS_ARG} --username "$(cat ${AUTH_DIR}/username)" --password-stdin ${NAME%%/*} ${REPO}
+		elif [[ -f "${AUTH_DIR}/tls.crt" ]] && [[ -f "${AUTH_DIR}/tls.key" ]]; then
+			if [[ "${AUTH_PASS_CREDENTIALS}" == "true" ]]; then
+				PASS_CREDENTIALS_ARG="--pass-credentials"
+			fi
+			${HELM} repo add ${CA_FILE_ARG} ${PASS_CREDENTIALS_ARG} --cert-file ${AUTH_DIR}/tls.crt --key-file ${AUTH_DIR}/tls.key ${NAME%%/*} ${REPO}
 		else
 			${HELM} repo add ${CA_FILE_ARG} ${NAME%%/*} ${REPO}
 		fi

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.19 as extract
 RUN apk add -U curl ca-certificates
 ARG ARCH
-RUN curl https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl -sL https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl https://get.helm.sh/helm-v3.14.2-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl -sL https://get.helm.sh/helm-v3.15.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 COPY entry /usr/bin/
 


### PR DESCRIPTION
Currently the `spec.authSecret` must be a [Basic authentication Secret](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret). This adds support for [TLS Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets).

* https://github.com/k3s-io/k3s/issues/10124