### PR TITLE
Bump helm version and bump plugin deps when building

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,20 +3,26 @@ RUN apk add -U curl ca-certificates
 ARG ARCH
 RUN curl -sL https://get.helm.sh/helm-v2.17.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v2
-RUN curl -sL https://get.helm.sh/helm-v3.15.0-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+RUN curl -sL https://get.helm.sh/helm-v3.15.3-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 RUN mv /usr/bin/helm /usr/bin/helm_v3
 COPY entry /usr/bin/
 
-FROM golang:1.22-alpine3.19 as plugins
+FROM golang:1.22-alpine3.20 as plugins
 RUN apk add -U curl ca-certificates build-base binutils-gold
 ARG ARCH
 COPY --from=extract /usr/bin/helm_v3 /usr/bin/helm
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     curl -sL https://github.com/k3s-io/helm-set-status/archive/refs/tags/v0.2.0.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \
-    make -C /go/src/github.com/k3s-io/helm-set-status install
+    cd /go/src/github.com/k3s-io/helm-set-status && \
+    go get -u ./... && \
+    go mod tidy && \
+    make install
 RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
     curl -sL https://github.com/k3s-io/helm-mapkubeapis/archive/refs/tags/v0.4.1-k3s1.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/helm/helm-mapkubeapis && \
-    make -C /go/src/github.com/helm/helm-mapkubeapis && \
+    cd /go/src/github.com/helm/helm-mapkubeapis && \
+    go get -u ./... && \
+    go mod tidy && \
+    make && \
     mkdir -p /root/.local/share/helm/plugins/helm-mapkubeapis && \
     cp -vr /go/src/github.com/helm/helm-mapkubeapis/plugin.yaml \
            /go/src/github.com/helm/helm-mapkubeapis/bin \


### PR DESCRIPTION
* Bump helm v3 to v3.15.3
* Update modules in plugins when building. Most of these plugins don't update often, so they tend to collect stale deps that show up on vuln scans.
* Ref: https://github.com/k3s-io/k3s/issues/10556