### PR TITLE
Exit with unique code for v2 charts

### DIFF
--- a/entry
+++ b/entry
@@ -150,7 +150,7 @@ set +v -x
 if [[ "${HELM_VERSION}" == "v2" ]]; then
 	echo "Helm v2 is EOL effective 2020-11-13; upgrade your chart to helm v3" >> ${TERM_LOG}
 	echo "Helm v2 is EOL effective 2020-11-13; upgrade your chart to helm v3"
-	exit 1
+	exit 64
 fi
 
 shopt -s nullglob


### PR DESCRIPTION
Exiting with a unique code for v2 charts allows us to tell the job to not retry on error using https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-failure-policy