### PR TITLE
Use `helm upgrade --install` to remediate failed releases

### DIFF
--- a/entry
+++ b/entry
@@ -16,7 +16,7 @@ helm_update() {
 			exit
 		fi
 		echo "Uninstalling ${HELM} chart" >> ${TERM_LOG}
-		${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait || true
+		${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait ${TIMEOUT_ARG} || true
 		exit
 	fi
 
@@ -43,6 +43,7 @@ helm_update() {
 			exit
 		else
 			STATUS=failed
+			REINSTALL_ACTION=reinstall
 		fi
 	fi
 
@@ -58,16 +59,24 @@ helm_update() {
 		exit
 	fi
 
-	# The chart is in a bad state; try uninstalling it first
+	# The chart is in a bad state; try reinstalling, upgrading, or installing
 	if [[ "${STATUS}" =~ ^(deleted|failed|null|unknown)$ ]]; then
 		if [[ "${FAILURE_POLICY:-reinstall}" == "reinstall" ]]; then
-			echo "Uninstalling ${STATUS} ${HELM} chart" >> ${TERM_LOG}
-			${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait
-			echo Deleted
-			# Try installing now that we've uninstalled
-			echo "Installing ${HELM} chart" >> ${TERM_LOG}
-			${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${INSECURE_TLS_ARG} ${PLAIN_HTTP_ARG} ${TIMEOUT_ARG} ${VALUES}
-			exit
+			if [[ "${REINSTALL_ACTION:-upgrade}" == "reinstall" ]]; then
+				echo "Uninstalling ${STATUS} ${HELM} chart" >> ${TERM_LOG}
+				${HELM} uninstall ${NAME} --namespace ${TARGET_NAMESPACE} --wait ${TIMEOUT_ARG}
+				echo Deleted
+				# Try installing now that we've uninstalled
+				echo "Installing ${HELM} chart" >> ${TERM_LOG}
+				${HELM} "$@" ${NAME_ARG} ${NAME} "${CHART}" ${CA_FILE_ARG} ${INSECURE_TLS_ARG} ${PLAIN_HTTP_ARG} ${TIMEOUT_ARG} ${VALUES}
+				exit
+			else
+				echo "Upgrading or installing ${STATUS} ${HELM} chart" >> ${TERM_LOG}
+				echo "Upgrading or installing ${STATUS} ${NAME}"
+				shift 1
+				${HELM} upgrade --install "$@" ${NAME} "${CHART}" ${CA_FILE_ARG} ${INSECURE_TLS_ARG} ${PLAIN_HTTP_ARG} ${TIMEOUT_ARG} ${VALUES}
+				exit
+			fi
 		else
 			echo "Release status is '${STATUS}' and failure policy is '${FAILURE_POLICY}', not 'reinstall'; waiting for operator intervention" >> ${TERM_LOG}
 			echo "Release status is '${STATUS}' and failure policy is '${FAILURE_POLICY}', not 'reinstall'; waiting for operator intervention"


### PR DESCRIPTION
This PR intends to address some issues I've encountered on fresh deployments.

### Problem

My environment is:
* K3s version v1.24.17+k3s1 installed on single node
* CRDs and operators (e.g., [cert-manager](https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml), [cluster-operator](https://github.com/rabbitmq/cluster-operator/releases/download/v1.11.1/cluster-operator.yml), [messaging-topology-operator](https://github.com/rabbitmq/messaging-topology-operator/releases/download/v1.14.2/messaging-topology-operator-with-certmanager.yaml)) defined as static content in `/var/lib/rancher/k3s/server/manifests` directory
* HelmChart resources (which depend on CRDs/operators) also defined in the `manifests` directory
* K3s is started, manifests are picked up and applied by kubelet

In this setup, there is no guarantee that CRDs and operators will be ready before the HelmChart resources are applied.

What I see is a `helm install|uninstall` storm when the initial install fails due to RabbitMQ webhooks not being available.  For example, an install failed with the following error: 
```
Internal error occurred: failed calling webhook "vvhost.kb.io": failed to call webhook: Post "https://webhook-service.rabbitmq-system.svc:443/validate-rabbitmq-com-v1beta1-vhost?timeout=10s": no endpoints available for service "webhook-service"
```

This failure triggered a `helm uninstall` operation (and a subsequent `helm install` operation), which should have been fine but wasn't because the uninstall got stuck.  PVCs were stuck "Terminating" and the `helm uninstall` default 5m timeout was reached.  The next `helm install` operation completed "successfully" without recreating these PVCs, leaving the system in an unexpected state.

### Fix

First, pass `${TIMEOUT_ARGS}` to all `helm uninstall` operations.  This feels safer and more appropriate than using the default 5m timeout.  This behavior is consistent with the [current Helm Controller documentation](https://docs.k3s.io/helm) which states that `spec.timeout` applies to "Helm operations" (not just "install").

Second, try to handle reinstalls more efficiently.  If the release is `pending-install|pending-rollback|uninstalling`, then proceed to uninstall and reinstall -- i.e., no change to current behavior.  If the release is `deleted|failed|null|unknown`, use `helm upgrade --install` instead to redeploy it.  This should be safe to do in this state and is more efficient than the current uninstall/reinstall loop.