### PR TITLE
Move to Github Actions for Release CI, publish to Dockerhub and GHCR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,27 +20,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/klipper-helm"
-    tag: "${DRONE_TAG}-amd64"
-    username:
-      from_secret: docker_username
-    build_args:
-    - ARCH=amd64
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
 volumes:
 - name: docker
   host:
@@ -67,27 +46,6 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
-
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    dockerfile: Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/klipper-helm"
-    tag: "${DRONE_TAG}-arm64"
-    username:
-      from_secret: docker_username
-    build_args:
-    - ARCH=arm64
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
 
 volumes:
 - name: docker
@@ -116,68 +74,10 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: docker-publish
-  # latest tag is no longer available for ARM 32-bit
-  image: plugins/docker:linux-arm
-  settings:
-    dockerfile: package/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: "rancher/klipper-helm"
-    tag: "${DRONE_TAG}-arm"
-    username:
-      from_secret: docker_username
-    build_args:
-    - ARCH=arm
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
 volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-
----
-kind: pipeline
-name: manifest
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: manifest
-  image: plugins/manifest
-  settings:
-    username:
-      from_secret: docker_username
-    password:
-      from_secret: docker_password
-    platforms:
-      - linux/amd64
-      - linux/arm64
-      - linux/arm
-    target: "rancher/klipper-helm:${DRONE_TAG}"
-    template: "rancher/klipper-helm:${DRONE_TAG}-ARCH"
-  when:
-    instance:
-    - drone-publish.k3s.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
-depends_on:
-- amd64
-- arm64
-- arm
 
 ...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,28 +5,39 @@ on:
     types:
       - created
 
+env:
+  DOCKERHUB_REPO: ${{ secrets.DOCKER_USER }}/klipper-helm
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
+
 jobs:
-  release:
-    runs-on: ubuntu-22.04
-    
-    permissions:
-      contents: read
-      packages: write
-    
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+          - arm64
+          - arm/v7
     steps:
-      - name: Login to Docker Hub
-        if: github.repository_owner == 'k3s-io'
-        uses: docker/login-action@v3
+      - name: Replace / with -
+        run: |
+          echo "ARCH=${${{ matrix.platform }}//\//-}" >> $GITHUB_ENV
+
+      - name: Docker source meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          username: k3s-io
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Login to Docker Hub (forks)
-        if: github.repository_owner != 'k3s-io'
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
-
+      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -40,13 +51,82 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          platforms: linux/${{ matrix.platform }}
+          # Push both the digest and a platform-specific tag, digest 
+          # is used for the manifest merge step
           tags: |
-            ${{ github.repository_owner }}/klipper-helm:latest
-            ${{ github.repository_owner }}/klipper-helm:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/klipper-helm:latest
-            ghcr.io/${{ github.repository_owner }}/klipper-helm:${{ github.ref_name }}
+            ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}-${{ env.ARCH }}
+            ${{ env.GHCR_REPO }}:${{ github.ref_name }}-${{ env.ARCH }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.ARCH }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+   
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+  
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,20 @@ on:
       - created
 
 env:
-  DOCKERHUB_REPO: ${{ secrets.DOCKER_USER }}/klipper-helm
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set DOCKERHUB_REPO
+        run: |
+          if [ "${{ github.repository_owner }}" != "k3s-io" ]; then
+            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
+          else
+            echo "DOCKERHUB_REPO=${{ github.repository_owner }}/klipper-helm" >> $GITHUB_ENV
+          fi
+
       - name: Docker source meta
         id: meta
         uses: docker/metadata-action@v5
@@ -21,10 +28,27 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}
             ${{ env.GHCR_REPO }}
 
-      - name: Login to Docker Hub
+      - name: "Read Vault secrets"
+        if: github.repository_owner == 'k3s-io'
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_TOKEN ;
+    
+      - name: Login to DockerHub with Rancher Secrets
+        if: github.repository_owner == 'k3s-io'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      # For forks, setup DockerHub login with GHA secrets
+      - name: Login to DockerHub with GHA Secrets
+        if: github.repository_owner != 'k3s-io'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       
       - name: Login to GitHub Container Registry
@@ -74,6 +98,14 @@ jobs:
         run: |
           platform=${{ matrix.platform }}
           echo "ARCH=${platform//\//-}" >> $GITHUB_ENV
+      
+      - name: Set DOCKERHUB_REPO
+        run: |
+          if [ "${{ github.repository_owner }}" != "k3s-io" ]; then
+            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
+          else
+            echo "DOCKERHUB_REPO=${{ github.repository_owner }}/klipper-helm" >> $GITHUB_ENV
+          fi
 
       - name: Docker source meta
         id: meta
@@ -86,9 +118,9 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-      
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -140,11 +172,36 @@ jobs:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
-   
-      - name: Login to Docker Hub
+      
+      - name: Set DOCKERHUB_REPO
+        run: |
+          if [ "${{ github.repository_owner }}" != "k3s-io" ]; then
+            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
+          else
+            echo "DOCKERHUB_REPO=${{ github.repository_owner }}/klipper-helm" >> $GITHUB_ENV
+          fi
+
+      - name: "Read Vault secrets"
+        if: github.repository_owner == 'k3s-io'
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_TOKEN ;
+      
+      - name: Login to DockerHub with Rancher Secrets
+        if: github.repository_owner == 'k3s-io'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USER }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+  
+      # For forks, setup DockerHub login with GHA secrets
+      - name: Login to DockerHub with GHA Secrets
+        if: github.repository_owner != 'k3s-io'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
   
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Login to Docker Hub
+        if: github.repository_owner == 'k3s-io'
+        uses: docker/login-action@v3
+        with:
+          username: k3s-io
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to Docker Hub (forks)
+        if: github.repository_owner != 'k3s-io'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/klipper-helm:latest
+            ${{ github.repository_owner }}/klipper-helm:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/klipper-helm:latest
+            ghcr.io/${{ github.repository_owner }}/klipper-helm:${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,62 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    steps:
+      - name: Docker source meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-amd64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-arm:
+    runs-on: ubuntu-22.04-arm
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - amd64
+          - arm64
           - arm/v7
     steps:
       - name: Replace / with -
@@ -72,62 +123,11 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  build-arm64:
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/arm64
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-arm64
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
   merge-manifests:
     runs-on: ubuntu-latest
     needs:
       - build
-      - build-arm64
+      - build-arm
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
       matrix:
         platform:
           - amd64
-          - arm64
           - arm/v7
     steps:
       - name: Replace / with -
         run: |
-          echo "ARCH=${${{ matrix.platform }}//\//-}" >> $GITHUB_ENV
+          platform=${{ matrix.platform }}
+          echo "ARCH=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Docker source meta
         id: meta
@@ -56,11 +56,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.platform }}
-          # Push both the digest and a platform-specific tag, digest 
-          # is used for the manifest merge step
-          tags: |
-            ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}-${{ env.ARCH }}
-            ${{ env.GHCR_REPO }}:${{ github.ref_name }}-${{ env.ARCH }}
           outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -77,10 +72,62 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  merge:
+  build-arm64:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Docker source meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/arm64
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-arm64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-manifests:
     runs-on: ubuntu-latest
     needs:
       - build
+      - build-arm64
 
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM alpine:3.21 AS extract
 RUN apk add -U curl ca-certificates
-ARG ARCH
-RUN curl -sL https://get.helm.sh/helm-v3.16.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+ARG TARGETARCH
+RUN if [ "${TARGETARCH}" = "arm/v7" ]; then \
+        ARCH="arm" ; \
+    else \
+        ARCH="${TARGETARCH}" ; \
+    fi && \
+    curl -sL https://get.helm.sh/helm-v3.16.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 COPY entry /usr/bin/
 
 FROM golang:1.24-alpine3.20 AS plugins
 RUN apk add -U curl ca-certificates build-base binutils-gold
-ARG ARCH
 COPY --from=extract /usr/bin/helm /usr/bin/helm
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     curl -sL https://github.com/k3s-io/helm-set-status/archive/refs/tags/v0.3.0.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \


### PR DESCRIPTION
- Remove release steps from Drone CI. Note that PR CI still runs there and test builds.
- Arrived at the following setup for CI release:
    - All 3 architectures are build in parallel, pushing digest releases to dockerhub and GHCR
    - At the end, a merge-manifests job combines them into the actual tagged release and pushed to registries
    - amd64 is built on amd64 host
    - arm64 is built on arm64 host
    - arm32 is emulated on arm64 host (way better performance than emulating on amd64 host)
- `latest` tags are now published. 
- `VERSION-ARCH` tags are no longer published due to limitations on docker push action. So no more `v0.4.10-arm` tag, just the combined tag of `v0.4.10`. 

Note the following must be added before this CI can work
- Action secret `DOCKER_USERNAME` .... user account (for k3s-io this will be rancher, due to legacy publishing)
- Action secret `DOCKER_TOKEN` dockerhub api token with "read/write" permissions

## Linked Issue
https://github.com/rancherlabs/eio/issues/3134