### PR TITLE
bump helm CLI binary to version 3.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN if [ "${TARGETARCH}" = "arm/v7" ]; then \
     else \
         ARCH="${TARGETARCH}" ; \
     fi && \
-    curl -sL https://get.helm.sh/helm-v3.16.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+    curl -sL https://get.helm.sh/helm-v3.18.1-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 COPY entry /usr/bin/
 
 FROM golang:1.24-alpine3.20 AS plugins


### PR DESCRIPTION
Found this while checking if CVE-2025-32386 is fixed with RKE2's recent stable version 1.32.5 - conclusion: it's not and I think the reason is because its not bumped in k3s/klipper-helm and then dependa-botted to rke2.

Try to contribute/help fixing this :-)