### PR TITLE
chore(deps): bump Helm to v3.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN go version
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     curl -sL https://github.com/k3s-io/helm-set-status/archive/refs/tags/v0.3.0.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \
     cd /go/src/github.com/k3s-io/helm-set-status && \
-    go mod edit --replace helm.sh/helm/v3=helm.sh/helm/v3@v3.19.4 && \
+    go mod edit --replace helm.sh/helm/v3=helm.sh/helm/v3@vv3.19.4 && \
     go mod tidy && \
     make install
 RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
     curl -sL https://github.com/helm/helm-mapkubeapis/archive/refs/tags/v0.6.1.tar.gz | tar xvzf - --strip-components=1 -C /go/src/github.com/helm/helm-mapkubeapis && \
     cd /go/src/github.com/helm/helm-mapkubeapis && \
-    go mod edit --replace helm.sh/helm/v3=helm.sh/helm/v3@v3.19.4 && \
+    go mod edit --replace helm.sh/helm/v3=helm.sh/helm/v3@vv3.19.4 && \
     go mod tidy && \
     make && \
     mkdir -p /root/.local/share/helm/plugins/helm-mapkubeapis && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN if [ "${TARGETARCH}" = "arm/v7" ]; then \
     else \
         ARCH="${TARGETARCH}" ; \
     fi && \
-    curl -sL https://get.helm.sh/helm-v3.19.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
+    curl -sL https://get.helm.sh/helm-vv3.19.4-linux-${ARCH}.tar.gz | tar xvzf - --strip-components=1 -C /usr/bin
 COPY entry /usr/bin/
 
 FROM golang:1.24-alpine3.22 AS plugins


### PR DESCRIPTION


Automated update from updatecli.

This PR updates Helm to version v3.19.4 on the 3.x major release line.


---



<Actions>
    <action id="e24fde90ea8095de5e4d2053ee6f15e14a7efa36e338c4c52997a5c3ffad180a">
        <h3>Bump Helm version</h3>
        <details id="af564d387e0fcde68a732d57b61f5cf9362c7c1ca0c0c92e32f058ae4f1641e8">
            <summary>Update Helm version for go module replacements</summary>
            <p>1 file(s) updated with &#34;helm.sh/helm/v3@vv3.19.4&#34;:&#xA;&#xA;* Dockerfile&#xA;</p>
            <details>
                <summary>v3.19.4</summary>
                <pre>Helm v3.19.4 is a security fix for a Go CVE in the previous tag. This patch release rebuilds the Helm `v3.19.3` release with the latest Go toolchain, to fix the Go CVE. Users are encouraged to upgrade.&#xD;&#xA;&#xD;&#xA;The community keeps growing, and we&#39;d love to see you there!&#xD;&#xA;&#xD;&#xA;- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):&#xD;&#xA;  -  for questions and just to hang out&#xD;&#xA;  -  for discussing PRs, code, and bugs&#xD;&#xA;- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)&#xD;&#xA;- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)&#xD;&#xA;&#xD;&#xA;## Installation and Upgrading&#xD;&#xA;&#xD;&#xA;Download Helm v3.19.4. The common platform binaries are here:&#xD;&#xA;&#xD;&#xA;- [MacOS amd64](https://get.helm.sh/helm-v3.19.4-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-darwin-amd64.tar.gz.sha256sum) / d9c9b1fc499c54282c4127c60cdd506da2c6202506b708a2b45fb6dfdb318f43)&#xD;&#xA;- [MacOS arm64](https://get.helm.sh/helm-v3.19.4-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-darwin-arm64.tar.gz.sha256sum) / 7e82ca63fe80a298cecefad61d0c10bc47963ff3551e94ab6470be6393a6a74b)&#xD;&#xA;- [Linux amd64](https://get.helm.sh/helm-v3.19.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-amd64.tar.gz.sha256sum) / 759c656fbd9c11e6a47784ecbeac6ad1eb16a9e76d202e51163ab78504848862)&#xD;&#xA;- [Linux arm](https://get.helm.sh/helm-v3.19.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-arm.tar.gz.sha256sum) / fcbb21b657c46ad646542964c262c4efb595bc60621e34273c1a2bb92eaff1dc)&#xD;&#xA;- [Linux arm64](https://get.helm.sh/helm-v3.19.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-arm64.tar.gz.sha256sum) / 9e1064f5de43745bdedbff2722a1674d0397bc4b4d8d8196d52a2b730909fe62)&#xD;&#xA;- [Linux i386](https://get.helm.sh/helm-v3.19.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-386.tar.gz.sha256sum) / 5bbf5541cb021c021a7f5b3e59e3808cc09678aa2650ece24c78f8a277466c0b)&#xD;&#xA;- [Linux ppc64le](https://get.helm.sh/helm-v3.19.4-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-ppc64le.tar.gz.sha256sum) / a38d8f75406f9bc3e12d1ebf8819fd563a5156ada6fe665402732932eec9c743)&#xD;&#xA;- [Linux s390x](https://get.helm.sh/helm-v3.19.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-s390x.tar.gz.sha256sum) / d153b3a316ce3f2936e601d94db5909aae4fbd5d1a4b28760fad2dd18c2bb749)&#xD;&#xA;- [Linux riscv64](https://get.helm.sh/helm-v3.19.4-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-riscv64.tar.gz.sha256sum) / 9d90a7532b426e5d99edfa9fa93e1dba4729f96a3b493974e847651a9aa34020)&#xD;&#xA;- [Windows amd64](https://get.helm.sh/helm-v3.19.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.19.4-windows-amd64.zip.sha256sum) / 18e7d1b970dfb6f4f8ddbbd1659d75d90ca818a47519411c4cc305b918508d36)&#xD;&#xA;- [Windows arm64](https://get.helm.sh/helm-v3.19.4-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.19.4-windows-arm64.zip.sha256sum) / da870dbb870e5cad243f5c7dca54f27be289237a97d84077c885769a06394223)&#xD;&#xA;&#xD;&#xA;This release was signed with `208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155` and can be found at @scottrigby [keybase account](https://keybase.io/r6by). Please use the attached signatures for verifying this release using `gpg`.&#xD;&#xA;&#xD;&#xA;The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.&#xD;&#xA;&#xD;&#xA;## What&#39;s Next&#xD;&#xA;&#xD;&#xA;- 3.19.5 and 4.0.4 are the next patch releases and will be on January 14, 2026&#xD;&#xA;- 3.20.0 and 4.1.0 is the next minor releases and will be on January 21, 2026&#xD;&#xA;&#xD;&#xA;## Changelog&#xD;&#xA;&#xD;&#xA;- Use latest patch release of Go in releases 7cfb6e486dac026202556836bb910c37d847793e (Matt Farina)&#xD;&#xA;- chore(deps): bump github.com/gofrs/flock from 0.12.1 to 0.13.0 59c951f309511dcb017900b6a19836e5bcbade04 (dependabot[bot])&#xD;&#xA;- chore(deps): bump github.com/cyphar/filepath-securejoin d45f3f15dfbc05320add596102ce3ae220825ff1 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/crypto from 0.44.0 to 0.45.0 d4595449c7bd2a82f1ae23b11711f2b7b219ed32 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/term from 0.36.0 to 0.37.0 becd3876eb126cb83d8571e6e3826645e941d400 (dependabot[bot])&#xD;&#xA;- chore(deps): bump the k8s-io group with 7 updates edb1579fd0d9ed81fb451ce03c68bd6365374173 (dependabot[bot])</pre>
            </details>
        </details>
        <details id="f4a1579ddde1c63e24f24db5a940ce1b40229225e745b02e919d332fc3a6c8e3">
            <summary>Update Helm version in Dockerfile download URL</summary>
            <p>1 file(s) updated with &#34;helm-vv3.19.4-linux&#34;:&#xA;&#xA;* Dockerfile&#xA;</p>
            <details>
                <summary>v3.19.4</summary>
                <pre>Helm v3.19.4 is a security fix for a Go CVE in the previous tag. This patch release rebuilds the Helm `v3.19.3` release with the latest Go toolchain, to fix the Go CVE. Users are encouraged to upgrade.&#xD;&#xA;&#xD;&#xA;The community keeps growing, and we&#39;d love to see you there!&#xD;&#xA;&#xD;&#xA;- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):&#xD;&#xA;  -  for questions and just to hang out&#xD;&#xA;  -  for discussing PRs, code, and bugs&#xD;&#xA;- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)&#xD;&#xA;- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)&#xD;&#xA;&#xD;&#xA;## Installation and Upgrading&#xD;&#xA;&#xD;&#xA;Download Helm v3.19.4. The common platform binaries are here:&#xD;&#xA;&#xD;&#xA;- [MacOS amd64](https://get.helm.sh/helm-v3.19.4-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-darwin-amd64.tar.gz.sha256sum) / d9c9b1fc499c54282c4127c60cdd506da2c6202506b708a2b45fb6dfdb318f43)&#xD;&#xA;- [MacOS arm64](https://get.helm.sh/helm-v3.19.4-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-darwin-arm64.tar.gz.sha256sum) / 7e82ca63fe80a298cecefad61d0c10bc47963ff3551e94ab6470be6393a6a74b)&#xD;&#xA;- [Linux amd64](https://get.helm.sh/helm-v3.19.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-amd64.tar.gz.sha256sum) / 759c656fbd9c11e6a47784ecbeac6ad1eb16a9e76d202e51163ab78504848862)&#xD;&#xA;- [Linux arm](https://get.helm.sh/helm-v3.19.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-arm.tar.gz.sha256sum) / fcbb21b657c46ad646542964c262c4efb595bc60621e34273c1a2bb92eaff1dc)&#xD;&#xA;- [Linux arm64](https://get.helm.sh/helm-v3.19.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-arm64.tar.gz.sha256sum) / 9e1064f5de43745bdedbff2722a1674d0397bc4b4d8d8196d52a2b730909fe62)&#xD;&#xA;- [Linux i386](https://get.helm.sh/helm-v3.19.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-386.tar.gz.sha256sum) / 5bbf5541cb021c021a7f5b3e59e3808cc09678aa2650ece24c78f8a277466c0b)&#xD;&#xA;- [Linux ppc64le](https://get.helm.sh/helm-v3.19.4-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-ppc64le.tar.gz.sha256sum) / a38d8f75406f9bc3e12d1ebf8819fd563a5156ada6fe665402732932eec9c743)&#xD;&#xA;- [Linux s390x](https://get.helm.sh/helm-v3.19.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-s390x.tar.gz.sha256sum) / d153b3a316ce3f2936e601d94db5909aae4fbd5d1a4b28760fad2dd18c2bb749)&#xD;&#xA;- [Linux riscv64](https://get.helm.sh/helm-v3.19.4-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.19.4-linux-riscv64.tar.gz.sha256sum) / 9d90a7532b426e5d99edfa9fa93e1dba4729f96a3b493974e847651a9aa34020)&#xD;&#xA;- [Windows amd64](https://get.helm.sh/helm-v3.19.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.19.4-windows-amd64.zip.sha256sum) / 18e7d1b970dfb6f4f8ddbbd1659d75d90ca818a47519411c4cc305b918508d36)&#xD;&#xA;- [Windows arm64](https://get.helm.sh/helm-v3.19.4-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.19.4-windows-arm64.zip.sha256sum) / da870dbb870e5cad243f5c7dca54f27be289237a97d84077c885769a06394223)&#xD;&#xA;&#xD;&#xA;This release was signed with `208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155` and can be found at @scottrigby [keybase account](https://keybase.io/r6by). Please use the attached signatures for verifying this release using `gpg`.&#xD;&#xA;&#xD;&#xA;The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.&#xD;&#xA;&#xD;&#xA;## What&#39;s Next&#xD;&#xA;&#xD;&#xA;- 3.19.5 and 4.0.4 are the next patch releases and will be on January 14, 2026&#xD;&#xA;- 3.20.0 and 4.1.0 is the next minor releases and will be on January 21, 2026&#xD;&#xA;&#xD;&#xA;## Changelog&#xD;&#xA;&#xD;&#xA;- Use latest patch release of Go in releases 7cfb6e486dac026202556836bb910c37d847793e (Matt Farina)&#xD;&#xA;- chore(deps): bump github.com/gofrs/flock from 0.12.1 to 0.13.0 59c951f309511dcb017900b6a19836e5bcbade04 (dependabot[bot])&#xD;&#xA;- chore(deps): bump github.com/cyphar/filepath-securejoin d45f3f15dfbc05320add596102ce3ae220825ff1 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/crypto from 0.44.0 to 0.45.0 d4595449c7bd2a82f1ae23b11711f2b7b219ed32 (dependabot[bot])&#xD;&#xA;- chore(deps): bump golang.org/x/term from 0.36.0 to 0.37.0 becd3876eb126cb83d8571e6e3826645e941d400 (dependabot[bot])&#xD;&#xA;- chore(deps): bump the k8s-io group with 7 updates edb1579fd0d9ed81fb451ce03c68bd6365374173 (dependabot[bot])</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

