### PR TITLE
Fix issues with job replacement

### DIFF
--- a/entry
+++ b/entry
@@ -134,9 +134,12 @@ check_revision() {
   if [[ -n "${EXPECTED_RELEASE_REVISION}" ]] && [[ "${EXPECTED_RELEASE_REVISION}" != "${REVISION}" ]]; then
     echo "Current release revision ${REVISION} does not match expected revision ${EXPECTED_RELEASE_REVISION}" >> ${TERM_LOG}
     echo "Current release revision ${REVISION} does not match expected revision ${EXPECTED_RELEASE_REVISION}"
-    exit 64
+    exit
   fi
 }
+
+# do not interrupt helm while it is running, or it will likely leave the release in a pending state
+trap "" SIGINT SIGTERM
 
 export CA_FILE=/config/ca-file.pem
 export CA_DIR=/ca-files


### PR DESCRIPTION
Do not exit with error if the revision does not match, as retrying will not help, and trap TERM/INT to avoid interrupting helm while it is working.

Without this change, the helm install/upgrade jobs look like they are failing when the revision checks are doing their job and properly handling out-of-order pod execution.

This is a follow-up to:
* https://github.com/k3s-io/klipper-helm/pull/120
* https://github.com/k3s-io/helm-controller/pull/312