### PR TITLE
Add riscv64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         platform:
           - arm64
           - arm/v7
+          - riscv64
 
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 ARG HELM_VERSION=v4.1.4
 ARG HELM_COMMIT=05fa37973dc9e42b76e1d2883494c87174b6074f
 
-FROM alpine/git:2.49.1 AS helm-src
+FROM alpine:3.23 AS helm-src
 ARG HELM_VERSION
 ARG HELM_COMMIT
-RUN git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.git /src/helm && \
+RUN apk add --no-cache git && \
+    git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.git /src/helm && \
     GIT_COMMIT="$(git -C /src/helm rev-parse HEAD)" && \
     if [ "${GIT_COMMIT}" != "${HELM_COMMIT}" ]; then \
         echo "Resolved Helm commit ${GIT_COMMIT} does not match expected ${HELM_COMMIT} for ${HELM_VERSION}"; \
@@ -21,6 +22,7 @@ RUN case "${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
         arm/v7|arm) export GOARCH="arm" GOARM="7" ;; \
         arm64)      export GOARCH="arm64" ;; \
         amd64)      export GOARCH="amd64" ;; \
+        riscv64)    export GOARCH="riscv64" ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" && exit 1 ;; \
     esac && \
     cd /src/helm && \


### PR DESCRIPTION
Adds linux/riscv64 to the klipper-helm image builds, mirroring what k3s-io/klipper-lb#89 did for klipper-lb. klipper-helm is one of the images k3s pulls at runtime, so it needs a riscv64 variant before k3s can run on riscv64 hardware.

It wasn't quite the one-liner klipper-lb was. Two things needed touching:

- The arch `case` in the Dockerfile exits on anything it doesn't recognise, so I added a `riscv64` branch (`GOARCH=riscv64`). helm and the plugins are Go, so they build without trouble.
- The `helm-src` stage was based on `alpine/git`, which has no riscv64 manifest, so the build can't resolve there. That stage only clones source, so I moved it to `alpine:3.23` plus `apk add git`. That base ships every target arch and doesn't depend on which runner the job lands on.

I built and ran the patched image natively on riscv64 hardware (a BananaPi-F3): it builds, and `helm version` reports `v4.1.4+g05fa379`. riscv64 goes through QEMU on the existing `build-arm` job. The job name is a bit of a misnomer now, so happy to rename it to something arch-neutral if you'd prefer, or leave it to keep the diff small.

Let me know if you'd rather I approached the helm-src change differently.