### PR TITLE
Add riscv64 support via larger CNCF runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,3 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/package"
-    labels:
-      - "kind/dependabot"
-    reviewers:
-      - "k3s-io/k3s-dev"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,33 +5,13 @@ on:
     paths-ignore:
       - "**.md"
 
-env:
-  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
+permissions:
+  contents: read
 
 jobs:
-  build:
+  build-amd64:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
     steps:
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -39,45 +19,38 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build Image
-        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           platforms: linux/amd64
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=false
+          push: false
+  build-riscv:
+    if: github.repository_owner == 'k3s-io'
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build Image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          platforms: linux/riscv64
+          push: false
   build-arm:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
         platform:
           - arm64
           - arm/v7
-
-    permissions:
-      contents: read
-
     steps:
       - name: Replace / with -
         run: |
           platform=${{ matrix.platform }}
           echo "ARCH=${platform//\//-}" >> $GITHUB_ENV
-      
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
@@ -86,8 +59,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build Image
-        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           platforms: linux/${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=false
+          push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
 
 jobs:
-  build:
+  build-amd64:
     runs-on: ubuntu-latest
 
     permissions:
@@ -101,8 +101,103 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-riscv64:
+    if: github.repository_owner == 'k3s-io'
+    # riscv64 emulation is incredibly slow on native GHA runners (10x slower).
+    # We brute force the problem with a larger CNCF runner.
+    # Testing between larger arm and x86 runners showed that x86 was 2x faster than arm.
+    runs-on: cncf-ubuntu-16-64-x86 
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for the Vault authentication
+      attestations: write # needed for actions/attest
+      artifact-metadata: write # needed to upload the attestations
+
+    steps:
+      - name: Set DOCKERHUB_REPO
+        run: |
+          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
+            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
+          else
+            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
+          fi
+
+      - name: Docker source meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_REPO }}
+            ${{ env.GHCR_REPO }}
+
+      - name: "Read Vault secrets"
+        if: github.repository_owner == 'k3s-io'
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_TOKEN ;
+    
+      - name: Login to DockerHub with Rancher Secrets
+        if: github.repository_owner == 'k3s-io'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
+
+      # For forks, setup DockerHub login with GHA secrets
+      - name: Login to DockerHub with GHA Secrets
+        if: github.repository_owner != 'k3s-io'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          platforms: linux/riscv64
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Attest
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        id: attest
+        with:
+          subject-name: ${{ env.GHCR_REPO }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: digests-riscv64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   build-arm:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -207,7 +302,8 @@ jobs:
   merge-manifests:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build-amd64
+      - build-riscv64
       - build-arm
 
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 ARG HELM_VERSION=v4.1.4
 ARG HELM_COMMIT=05fa37973dc9e42b76e1d2883494c87174b6074f
 
-FROM alpine/git:2.49.1 AS helm-src
+FROM alpine:3.24 AS helm-src
 ARG HELM_VERSION
 ARG HELM_COMMIT
+RUN apk add --no-cache git
 RUN git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.git /src/helm && \
     GIT_COMMIT="$(git -C /src/helm rev-parse HEAD)" && \
     if [ "${GIT_COMMIT}" != "${HELM_COMMIT}" ]; then \
@@ -12,7 +13,7 @@ RUN git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.
     fi && \
     printf '%s\n' "${GIT_COMMIT}" > /src/helm/.git-commit
 
-FROM golang:1.25-alpine3.23 AS helm
+FROM golang:1.25-alpine3.24 AS helm
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG HELM_VERSION
@@ -21,6 +22,7 @@ RUN case "${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
         arm/v7|arm) export GOARCH="arm" GOARM="7" ;; \
         arm64)      export GOARCH="arm64" ;; \
         amd64)      export GOARCH="amd64" ;; \
+        riscv64)    export GOARCH="riscv64" ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" && exit 1 ;; \
     esac && \
     cd /src/helm && \
@@ -41,7 +43,7 @@ RUN case "${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
       -o /usr/bin/helm ./cmd/helm
 COPY entry /usr/bin/
 
-FROM golang:1.25-alpine3.23 AS plugins
+FROM golang:1.25-alpine3.24 AS plugins
 ARG TARGETARCH
 ARG HELM_VERSION
 COPY --from=helm /usr/bin/helm /usr/bin/helm
@@ -71,7 +73,7 @@ RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
            /go/src/github.com/helm/helm-mapkubeapis/config \
            /root/.local/share/helm/plugins/helm-mapkubeapis/
 
-FROM alpine:3.23
+FROM alpine:3.24
 ARG BUILDDATE
 LABEL buildDate=$BUILDDATE
 RUN apk --no-cache upgrade && \


### PR DESCRIPTION
Supersedes community contributions of https://github.com/k3s-io/klipper-helm/pull/117. 

GitHub hosted runners are too slow for use QEMU emulation, and current RISE riscv runners have also proved insufficient (at this time). 

Instead we can use the larger CNCF 16 core runners to bring the builds down into the realm of "not horrible". Testing comes from https://github.com/k3s-io/klipper-helm/actions/runs/28120474070 

| Platform | Build Time | Notes |
| - | - | - |
| AMD64 GHA runner | 2m 31s | this is the performance goal |
| riscV64 emulation on GHA runner | 26m 8s | :( | 
| riscV64 emulation on 16vCPU-ARM CNCF  runner | 19m 59s | |
| riscV64 emulation on 16vCPU-x86 CNCF runner | 8m 16s | not great, but we can live with it |

Cleanup the PR workflow, we don't need to login or setup permissions, we just build the image and throw it away.


Signed-off-by: Derek Nola <derek.nola@suse.com>