### PR TITLE
Build with go cross-compilation and add riscv64 support 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,3 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/package"
-    labels:
-      - "kind/dependabot"
-    reviewers:
-      - "k3s-io/k3s-dev"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,33 +5,14 @@ on:
     paths-ignore:
       - "**.md"
 
-env:
-  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-
     steps:
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
 
@@ -39,55 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build Image
-        id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
-          platforms: linux/amd64
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=false
-
-  build-arm:
-    runs-on: ubuntu-22.04-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - arm64
-          - arm/v7
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Replace / with -
-        run: |
-          platform=${{ matrix.platform }}
-          echo "ARCH=${platform//\//-}" >> $GITHUB_ENV
-      
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Build Image
-        id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          platforms: linux/${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=false
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
+          push: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'k3s-io' && 'cncf-ubuntu-8-32-x86' || 'ubuntu-latest' }}
 
     steps:
       - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ env:
   GHCR_REPO: ghcr.io/${{ github.repository_owner }}/klipper-helm
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
 
     permissions:
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Set DOCKERHUB_REPO
         run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
+          if [ "${{ github.repository_owner }}" = "k3s-io" ]; then
             echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
           else
             echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
@@ -36,14 +36,14 @@ jobs:
             ${{ env.DOCKERHUB_REPO }}
             ${{ env.GHCR_REPO }}
 
-      - name: "Read Vault secrets"
+      - name: Read Vault secrets
         if: github.repository_owner == 'k3s-io'
         uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_TOKEN ;
-    
+
       - name: Login to DockerHub with Rancher Secrets
         if: github.repository_owner == 'k3s-io'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -51,110 +51,6 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_TOKEN }}
 
-      # For forks, setup DockerHub login with GHA secrets
-      - name: Login to DockerHub with GHA Secrets
-        if: github.repository_owner != 'k3s-io'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          platforms: linux/amd64
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Attest
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
-        id: attest
-        with:
-          subject-name: ${{ env.GHCR_REPO }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: digests-amd64
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  build-arm:
-    runs-on: ubuntu-22.04-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - arm64
-          - arm/v7
-
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # needed for the Vault authentication
-      attestations: write
-      artifact-metadata: write
-
-    steps:
-      - name: Replace / with -
-        run: |
-          platform=${{ matrix.platform }}
-          echo "ARCH=${platform//\//-}" >> $GITHUB_ENV
-      
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: Docker source meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
-      - name: "Read Vault secrets"
-        if: github.repository_owner == 'k3s-io'
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_TOKEN ;
-        
-      - name: Login to DockerHub with Rancher Secrets
-        if: github.repository_owner == 'k3s-io'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_TOKEN }}
-    
-      # For forks, setup DockerHub login with GHA secrets
       - name: Login to DockerHub with GHA Secrets
         if: github.repository_owner != 'k3s-io'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -175,121 +71,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - name: Build and push by digest
+      - name: Build and push image
         id: build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
-          platforms: linux/${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }},${{ env.GHCR_REPO }}",push-by-digest=true,name-canonical=true,push=true
-      
-      - name: Attest
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
-        id: attest
-        with:
-          subject-name: ${{ env.GHCR_REPO }}
-          subject-digest: ${{ steps.build.outputs.digest }}
-          push-to-registry: true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: digests-${{ env.ARCH }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge-manifests:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-      - build-arm
-
-    permissions:
-      contents: read
-      packages: write
-      id-token: write # needed for the Vault authentication
-      attestations: write # needed for actions/attest
-      artifact-metadata: write # needed to upload the attestations
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-      
-      - name: Set DOCKERHUB_REPO
-        run: |
-          if [ "${{ github.repository_owner }}" == "k3s-io" ]; then
-            echo "DOCKERHUB_REPO=rancher/klipper-helm" >> $GITHUB_ENV
-          else
-            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/klipper-helm" >> $GITHUB_ENV
-          fi
-
-      - name: "Read Vault secrets"
-        if: github.repository_owner == 'k3s-io'
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_TOKEN ;
-      
-      - name: Login to DockerHub with Rancher Secrets
-        if: github.repository_owner == 'k3s-io'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_TOKEN }}
-  
-      # For forks, setup DockerHub login with GHA secrets
-      - name: Login to DockerHub with GHA Secrets
-        if: github.repository_owner != 'k3s-io'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-  
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
-        with:
-          images: |
-            ${{ env.DOCKERHUB_REPO }}
-            ${{ env.GHCR_REPO }}
-
-      - name: Create manifest list and push
-        id: get-digest
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_REPO }}@sha256:%s ' *)
-          GHCR_DIGEST=$(docker buildx imagetools inspect ${{ env.GHCR_REPO }}:${{ steps.meta.outputs.version }} --raw | sha256sum | awk '{print "sha256:"$1}')
-          echo "ghcr_digest=$GHCR_DIGEST" >> $GITHUB_OUTPUT
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
 
       - name: Attest multi-arch image (GHCR)
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-name: ${{ env.GHCR_REPO }}
-          subject-digest: ${{ steps.get-digest.outputs.ghcr_digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
       - name: Inspect image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'k3s-io' && 'cncf-ubuntu-8-32-x86' || 'ubuntu-latest' }}
 
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 ARG HELM_VERSION=v4.1.4
 ARG HELM_COMMIT=05fa37973dc9e42b76e1d2883494c87174b6074f
 
-FROM alpine/git:2.49.1 AS helm-src
+FROM --platform=$BUILDPLATFORM alpine:3.24 AS helm-src
 ARG HELM_VERSION
 ARG HELM_COMMIT
+RUN apk add --no-cache git
 RUN git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.git /src/helm && \
     GIT_COMMIT="$(git -C /src/helm rev-parse HEAD)" && \
     if [ "${GIT_COMMIT}" != "${HELM_COMMIT}" ]; then \
@@ -12,15 +13,18 @@ RUN git clone --branch "${HELM_VERSION}" --depth 1 https://github.com/helm/helm.
     fi && \
     printf '%s\n' "${GIT_COMMIT}" > /src/helm/.git-commit
 
-FROM golang:1.25-alpine3.23 AS helm
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.24 AS helm
+ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG TARGETPLATFORM
 ARG HELM_VERSION
 COPY --from=helm-src /src/helm /src/helm
 RUN case "${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
         arm/v7|arm) export GOARCH="arm" GOARM="7" ;; \
         arm64)      export GOARCH="arm64" ;; \
         amd64)      export GOARCH="amd64" ;; \
+        riscv64)    export GOARCH="riscv64" ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" && exit 1 ;; \
     esac && \
     cd /src/helm && \
@@ -28,34 +32,36 @@ RUN case "${TARGETARCH}${TARGETVARIANT:+/${TARGETVARIANT}}" in \
     K8S_MODULES_MAJOR_VER="$(echo "${K8S_MODULES_VER}" | cut -d. -f1)" && \
     K8S_MODULES_MINOR_VER="$(echo "${K8S_MODULES_VER}" | cut -d. -f2)" && \
     GIT_COMMIT="$(cat .git-commit)" && \
-    CGO_ENABLED=0 go build -trimpath \
-      -ldflags "-w -s \
-      -X helm.sh/helm/v4/internal/version.version=${HELM_VERSION} \
-      -X helm.sh/helm/v4/internal/version.metadata= \
-      -X helm.sh/helm/v4/internal/version.gitCommit=${GIT_COMMIT} \
-      -X helm.sh/helm/v4/internal/version.gitTreeState=clean \
-      -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMajor=$((K8S_MODULES_MAJOR_VER + 1)) \
-      -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMinor=${K8S_MODULES_MINOR_VER} \
-      -X helm.sh/helm/v4/pkg/chartutil.k8sVersionMajor=$((K8S_MODULES_MAJOR_VER + 1)) \
-      -X helm.sh/helm/v4/pkg/chartutil.k8sVersionMinor=${K8S_MODULES_MINOR_VER}" \
-      -o /usr/bin/helm ./cmd/helm
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${GOARCH}" GOARM="${GOARM}" go build -trimpath \
+        -ldflags "-w -s \
+        -X helm.sh/helm/v4/internal/version.version=${HELM_VERSION} \
+        -X helm.sh/helm/v4/internal/version.metadata= \
+        -X helm.sh/helm/v4/internal/version.gitCommit=${GIT_COMMIT} \
+        -X helm.sh/helm/v4/internal/version.gitTreeState=clean \
+        -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMajor=$((K8S_MODULES_MAJOR_VER + 1)) \
+        -X helm.sh/helm/v4/pkg/lint/rules.k8sVersionMinor=${K8S_MODULES_MINOR_VER} \
+        -X helm.sh/helm/v4/pkg/chartutil.k8sVersionMajor=$((K8S_MODULES_MAJOR_VER + 1)) \
+        -X helm.sh/helm/v4/pkg/chartutil.k8sVersionMinor=${K8S_MODULES_MINOR_VER}" \
+        -o /usr/bin/helm ./cmd/helm
 COPY entry /usr/bin/
 
-FROM golang:1.25-alpine3.23 AS plugins
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.24 AS plugins
+ARG TARGETPLATFORM
+ARG TARGETOS
 ARG TARGETARCH
 ARG HELM_VERSION
 COPY --from=helm /usr/bin/helm /usr/bin/helm
-RUN apk add -U curl ca-certificates build-base $([ "${TARGETARCH}" = "arm64" ] && echo binutils-gold)
+RUN apk add -U --no-cache curl ca-certificates make git $([ "${TARGETARCH}" = "arm64" ] && echo binutils-gold)
 RUN go version
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     cd /tmp && \
-    curl -fsSL https://github.com/k3s-io/helm-set-status/archive/3a3a40923262fcd0bdf729b538cda7dd4b15b047/helm-set-status.tar.gz -o helm-set-status.tar.gz && \
+    curl -fsSL https://github.com/k3s-io/helm-set-status/archive/aa683c2b38a34bbd7261c5cd59e8d7c02e9d5c6e/helm-set-status.tar.gz -o helm-set-status.tar.gz && \
     tar xzf helm-set-status.tar.gz --strip-components=1 -C /go/src/github.com/k3s-io/helm-set-status && \
     rm -f /tmp/helm-set-status.tar.gz && \
     cd /go/src/github.com/k3s-io/helm-set-status && \
     go mod edit --replace helm.sh/helm/v4=helm.sh/helm/v4@"${HELM_VERSION}" && \
     go mod tidy && \
-    make install
+    make CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" HELM_PLUGIN_PATH=/root/.local/share/helm/plugins/helm-set-status install
 RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
     cd /tmp && \
     curl -fsSL https://github.com/helm/helm-mapkubeapis/archive/a8a487a350db0ca85fb4247afb7e220d5f254b6f/helm-mapkubeapis.tar.gz -o helm-mapkubeapis.tar.gz && \
@@ -64,14 +70,14 @@ RUN mkdir -p /go/src/github.com/helm/helm-mapkubeapis && \
     cd /go/src/github.com/helm/helm-mapkubeapis && \
     go mod edit --replace helm.sh/helm/v4=helm.sh/helm/v4@"${HELM_VERSION}" && \
     go mod tidy && \
-    make && \
+    make CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" build && \
     mkdir -p /root/.local/share/helm/plugins/helm-mapkubeapis && \
     cp -vr /go/src/github.com/helm/helm-mapkubeapis/plugin.yaml \
            /go/src/github.com/helm/helm-mapkubeapis/bin \
            /go/src/github.com/helm/helm-mapkubeapis/config \
            /root/.local/share/helm/plugins/helm-mapkubeapis/
 
-FROM alpine:3.23
+FROM alpine:3.24
 ARG BUILDDATE
 LABEL buildDate=$BUILDDATE
 RUN apk --no-cache upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG HELM_VERSION
 COPY --from=helm /usr/bin/helm /usr/bin/helm
-RUN apk add -U --no-cache curl ca-certificates make git $([ "${TARGETARCH}" = "arm64" ] && echo binutils-gold)
+RUN apk add -U --no-cache curl ca-certificates make git
 RUN go version
 RUN mkdir -p /go/src/github.com/k3s-io/helm-set-status && \
     cd /tmp && \


### PR DESCRIPTION
Utilize native Go cross-compilation for all build stages. An alternative to https://github.com/k3s-io/klipper-helm/pull/134

Add riscv64 support.

Remove binutils-gold as talked about in https://github.com/k3s-io/klipper-helm/pull/114 as this was resolved in go1.25+

Validated that E2E still works when this branch is used in a k3s build https://github.com/dereknola/k3s/actions/runs/28132742713