### PR TITLE
Patch x-net/x-crypto/x-text/oras-go CVEs (VEX Hub scan)

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,5 +1,5 @@
 # go.mod overrides applied at build time. See scripts/go-mod-overrides.sh.
 
-# golang.org/x/net: CVE-2026-33814 (net/http2 DoS), CVE-2026-39821 (x/net/idna punycode).
-# Drop once upstream Helm requires golang.org/x/net >= v0.55.0.
--replace golang.org/x/net=golang.org/x/net@v0.55.0
+# golang.org/x/net: CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
+# Drop once upstream Helm requires golang.org/x/net >= v0.56.0.
+-replace golang.org/x/net=golang.org/x/net@v0.56.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -3,3 +3,7 @@
 # golang.org/x/net: CVE-2026-46600 (x/net/dns/dnsmessage panic parsing invalid SVCB or HTTPS RR).
 # Drop once upstream Helm requires golang.org/x/net >= v0.56.0.
 -replace golang.org/x/net=golang.org/x/net@v0.56.0
+
+# golang.org/x/crypto: CVE-2026-39827 (MEDIUM), CVE-2026-56855, CVE-2026-78662 (ssh channel DoS) — golang.org/x/crypto/ssh.
+# Drop once upstream Helm requires golang.org/x/crypto >= v0.56.0.
+-replace golang.org/x/crypto=golang.org/x/crypto@v0.56.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -7,3 +7,7 @@
 # golang.org/x/crypto: CVE-2026-39827 (MEDIUM), CVE-2026-56855, CVE-2026-78662 (ssh channel DoS) — golang.org/x/crypto/ssh.
 # Drop once upstream Helm requires golang.org/x/crypto >= v0.56.0.
 -replace golang.org/x/crypto=golang.org/x/crypto@v0.56.0
+
+# golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
+# Drop once upstream Helm requires golang.org/x/text >= v0.39.0.
+-replace golang.org/x/text=golang.org/x/text@v0.39.0

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -11,3 +11,7 @@
 # golang.org/x/text: CVE-2026-56852 (infinite loop on invalid input).
 # Drop once upstream Helm requires golang.org/x/text >= v0.39.0.
 -replace golang.org/x/text=golang.org/x/text@v0.39.0
+
+# oras.land/oras-go/v2: CVE-2026-48978 (LOW).
+# Drop once upstream Helm requires oras.land/oras-go/v2 >= v2.6.1.
+-replace oras.land/oras-go/v2=oras.land/oras-go/v2@v2.6.1


### PR DESCRIPTION
Patches CVEs found in `rancher/klipper-helm` via the Rancher VEX Hub trivy scan. One commit per Go module.

### Changes
- **`golang.org/x/net` → `v0.56.0`** — CVE-2026-46600 (HIGH, dnsmessage panic).
- **`golang.org/x/crypto` → `v0.56.0`** — CVE-2026-56855 / CVE-2026-78662 (ssh channel DoS) and CVE-2026-39827.
- **`golang.org/x/text` → `v0.39.0`** — CVE-2026-56852 (HIGH, infinite loop).
- **`oras.land/oras-go/v2` → `v2.6.1`** — CVE-2026-48978 (LOW).

Build base is `golang:1.26`, satisfying x/crypto v0.56.0's go1.26 minimum.

Signed-off-by: Michael Fritch <mfritch@suse.com>
